### PR TITLE
feat/default_security_group_id output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -51,7 +51,7 @@ output "vpc_default_route_table_id" {
 }
 
 output "default_security_group_id" {
-  value       = try(aws_default_security_group.default[0])
+  value       = length(aws_default_security_group.default) > 0 ? join("", aws_default_security_group.default[*].id) : ""
   description = "ID of the default security group created by the VPC module."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,6 +50,11 @@ output "vpc_default_route_table_id" {
   description = "The ID of the route table created by default on VPC creation."
 }
 
+output "default_security_group_id" {
+  value = try(aws_default_security_group.default[0])
+  description = "ID of the default security group created by the VPC module."
+}
+
 output "tags" {
   value       = module.labels.tags
   description = "A mapping of tags to assign to the resource."
@@ -73,3 +78,4 @@ output "arn" {
   value       = join("", aws_flow_log.vpc_flow_log[*].arn)
   description = "Amazon Resource Name (ARN) of VPC"
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -51,7 +51,7 @@ output "vpc_default_route_table_id" {
 }
 
 output "default_security_group_id" {
-  value = try(aws_default_security_group.default[0])
+  value       = try(aws_default_security_group.default[0])
   description = "ID of the default security group created by the VPC module."
 }
 


### PR DESCRIPTION
## what
* Updated the clouddrove/terraform-aws-vpc module to include a new output variable.
* Added default_security_group_id as an output to retrieve the default security group ID.
* Used try() to prevent errors if the default security group creation is disabled.

## why
* Ensures Terraform does not fail if the default security group is not created.
* Improves module flexibility for users who disable the default security group.
* Enhances error handling and prevents unnecessary failures.

## references
* Related Terraform documentation: try() function.



