### PR TITLE
fix: removed depricated arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -200,7 +200,7 @@ resource "aws_kms_key_policy" "example" {
       },
       {
         "Effect" : "Allow",
-        "Principal" : { "Service" : "logs.${data.aws_region.current.name}.amazonaws.com" },
+        "Principal" : { "Service" : "logs.${data.aws_region.current.region}.amazonaws.com" },
         "Action" : [
           "kms:Encrypt*",
           "kms:Decrypt*",


### PR DESCRIPTION
## what  

- Replaced deprecated argument `aws_region.current.name` with `aws_region.current.region` across relevant configurations from the` aws_kms_key_policy` resource.

## why  
- The `name` attribute in `aws_region.current` is deprecated. The `region` attribute should be used instead to comply with the latest provider schema and avoid future compatibility issues.

## resource
- [Reference doc](https://registry.terraform.io/providers/hashicorp/aws/6.0.0-beta3/docs/data-sources/region)