### PR TITLE
fix(ci): enforce shared workflow source policy

### DIFF
--- a/.github/workflows/use-shared-stale.yml
+++ b/.github/workflows/use-shared-stale.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   stale:
-    uses: clouddrove-sandbox/terraform-shared-workflows/.github/workflows/stale.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr-stale.yml@main
     secrets:
       repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   validate-title:
-    uses: your-test-account/.github/.github/workflows/validate-pr-title.yml@main
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr-checks.yml@main
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary\n- replace non-approved reusable workflow sources\n- standardize to `clouddrove/github-shared-workflows`\n\n## Changes\n- .github/workflows/use-shared-stale.yml -> pr-stale reusable workflow\n- .github/workflows/validate-pr.yml -> pr-checks reusable workflow\n\nPolicy: reusable workflows must come only from clouddrove/github-shared-workflows.