### PR TITLE
ci: enforce reusable workflow source policy

### DIFF
--- a/.github/workflows/use-shared-stale.yml
+++ b/.github/workflows/use-shared-stale.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   stale:
-    uses: clouddrove-sandbox/terraform-shared-workflows/.github/workflows/stale.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/stale.yml@1.4.1
     secrets:
       repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   validate-title:
-    uses: your-test-account/.github/.github/workflows/validate-pr-title.yml@main
+    uses: clouddrove/github-shared-workflows/.github/workflows/validate-pr-title.yml@1.4.1
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR enforces reusable workflow source policy by switching workflow-call `uses:` sources to `clouddrove/github-shared-workflows`.

- validate-pr.yml -> clouddrove/github-shared-workflows/.github/workflows/validate-pr-title.yml@1.4.1
- use-shared-stale.yml -> clouddrove/github-shared-workflows/.github/workflows/stale.yml@1.4.1

No merge performed.