### PR TITLE
fix: use data.aws_region.current.name instead of .region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -214,7 +214,7 @@ resource "aws_kms_key_policy" "example" {
       var.flow_log_destination_type == "cloud-watch-logs" ? [{
         "Sid" : "AllowCloudWatchLogs",
         "Effect" : "Allow",
-        "Principal" : { "Service" : "logs.${data.aws_region.current.region}.amazonaws.com" },
+        "Principal" : { "Service" : "logs.${data.aws_region.current.name}.amazonaws.com" },
         "Action" : [
           "kms:Encrypt*",
           "kms:Decrypt*",


### PR DESCRIPTION
## Summary

The AWS provider's `aws_region` data source exposes the region identifier as `name`, not `region`. Using `data.aws_region.current.region` causes a terraform validate error:

```
Error: Unsupported attribute
  data.aws_region.current.region
  This object has no argument, nested block, or exported attribute named "region".
```

This PR replaces the single occurrence in `main.tf` (KMS policy for CloudWatch Logs flow log destinations).

Fixes #105

## Test plan
- [ ] `terraform validate` passes
- [ ] CI checks pass